### PR TITLE
Add ES to Server profile

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -1,5 +1,5 @@
 APIVersion: v1.13.0
-name: drupal8-tests
+name: drupal-static-elasticsearch
 type: drupal8
 docroot: web
 php_version: "7.3"

--- a/.ddev/docker-compose.elastichq.yaml
+++ b/.ddev/docker-compose.elastichq.yaml
@@ -1,0 +1,22 @@
+version: '3.6'
+services:
+  elastichq:
+    container_name: ddev-${DDEV_SITENAME}-elastichq
+    hostname: ${DDEV_SITENAME}-elastichq
+    image: elastichq/elasticsearch-hq
+    restart: always
+    ports:
+      - "5000"
+    labels:
+      com.ddev.site-name: ${DDEV_SITENAME}
+      com.ddev.approot: $DDEV_APPROOT
+    environment:
+      - VIRTUAL_HOST=$DDEV_HOSTNAME
+      - HTTP_EXPOSE=5000:5000
+      - HTTPS_EXPOSE=5443:5000
+      - HQ_DEFAULT_URL=http://elasticsearch:9200
+    volumes:
+      - ".:/mnt/ddev_config"
+  elasticsearch:
+    links:
+      - elastichq:elastichq

--- a/.ddev/docker-compose.elasticsearch.yaml
+++ b/.ddev/docker-compose.elasticsearch.yaml
@@ -1,0 +1,30 @@
+version: '3.6'
+services:
+  elasticsearch:
+    container_name: ddev-${DDEV_SITENAME}-elasticsearch
+    hostname: ${DDEV_SITENAME}-elasticsearch
+    image: elasticsearch:7.6.1
+    ports:
+      - "9200"
+      - "9300"
+    environment:
+      - cluster.name=docker-cluster
+      - discovery.type=single-node
+      - bootstrap.memory_lock=true
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+      - VIRTUAL_HOST=$DDEV_HOSTNAME
+      - HTTP_EXPOSE=9200:9200
+      - HTTPS_EXPOSE=9201:9200
+    labels:
+      com.ddev.site-name: ${DDEV_SITENAME}
+      com.ddev.approot: $DDEV_APPROOT
+    volumes:
+      - elasticsearch:/usr/share/elasticsearch/data
+      - ".:/mnt/ddev_config"
+  web:
+    links:
+      - elasticsearch:elasticsearch
+
+volumes:
+  elasticsearch:
+    name: "${DDEV_SITENAME}-elasticsearch"

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
         "composer/installers": "^1.2",
         "drupal/core-composer-scaffold": "^8.8",
         "drupal/core-recommended": "^8.8",
-        "drush/drush": "^10.2"
+        "drush/drush": "^10.2",
+        "nodespark/des-connector": "dev-master"
     },
     "require-dev": {
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7d70d7de27c1783bce8d0d260f176631",
+    "content-hash": "f79d4848dded1ba14ff34a54040a0212",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -2159,6 +2159,61 @@
             "time": "2019-08-13T17:33:27+00:00"
         },
         {
+            "name": "elasticsearch/elasticsearch",
+            "version": "v5.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/elastic/elasticsearch-php.git",
+                "reference": "48b8a90e2b97b4d69ce42851c1b9e59f8054661a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/elastic/elasticsearch-php/zipball/48b8a90e2b97b4d69ce42851c1b9e59f8054661a",
+                "reference": "48b8a90e2b97b4d69ce42851c1b9e59f8054661a",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/ringphp": "~1.0",
+                "php": "^5.6|^7.0",
+                "psr/log": "~1.0"
+            },
+            "require-dev": {
+                "cpliakas/git-wrapper": "~1.0",
+                "doctrine/inflector": "^1.1",
+                "mockery/mockery": "0.9.4",
+                "phpunit/phpunit": "^4.7|^5.4",
+                "sami/sami": "~3.2",
+                "symfony/finder": "^2.8",
+                "symfony/yaml": "^2.8"
+            },
+            "suggest": {
+                "ext-curl": "*",
+                "monolog/monolog": "Allows for client-level logging and tracing"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Elasticsearch\\": "src/Elasticsearch/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Zachary Tong"
+                }
+            ],
+            "description": "PHP Client for Elasticsearch",
+            "keywords": [
+                "client",
+                "elasticsearch",
+                "search"
+            ],
+            "time": "2019-07-18T15:11:30+00:00"
+        },
+        {
             "name": "grasmash/expander",
             "version": "1.0.0",
             "source": {
@@ -2441,6 +2496,109 @@
             "time": "2019-07-01T23:21:34+00:00"
         },
         {
+            "name": "guzzlehttp/ringphp",
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/RingPHP.git",
+                "reference": "5e2a174052995663dd68e6b5ad838afd47dd615b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/RingPHP/zipball/5e2a174052995663dd68e6b5ad838afd47dd615b",
+                "reference": "5e2a174052995663dd68e6b5ad838afd47dd615b",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/streams": "~3.0",
+                "php": ">=5.4.0",
+                "react/promise": "~2.0"
+            },
+            "require-dev": {
+                "ext-curl": "*",
+                "phpunit/phpunit": "~4.0"
+            },
+            "suggest": {
+                "ext-curl": "Guzzle will use specific adapters if cURL is present"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Ring\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Provides a simple API and specification that abstracts away the details of HTTP into a single PHP function.",
+            "abandoned": true,
+            "time": "2018-07-31T13:22:33+00:00"
+        },
+        {
+            "name": "guzzlehttp/streams",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/streams.git",
+                "reference": "47aaa48e27dae43d39fc1cea0ccf0d84ac1a2ba5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/streams/zipball/47aaa48e27dae43d39fc1cea0ccf0d84ac1a2ba5",
+                "reference": "47aaa48e27dae43d39fc1cea0ccf0d84ac1a2ba5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Stream\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Provides a simple abstraction over streams of data",
+            "homepage": "http://guzzlephp.org/",
+            "keywords": [
+                "Guzzle",
+                "stream"
+            ],
+            "abandoned": true,
+            "time": "2014-10-12T19:18:40+00:00"
+        },
+        {
             "name": "jakub-onderka/php-console-color",
             "version": "v0.2",
             "source": {
@@ -2480,6 +2638,7 @@
                     "email": "jakub.onderka@gmail.com"
                 }
             ],
+            "abandoned": "php-parallel-lint/php-console-color",
             "time": "2018-09-29T17:23:10+00:00"
         },
         {
@@ -2526,6 +2685,7 @@
                 }
             ],
             "description": "Highlight PHP code in terminal",
+            "abandoned": "php-parallel-lint/php-console-highlighter",
             "time": "2018-09-29T18:48:56+00:00"
         },
         {
@@ -2709,6 +2869,51 @@
                 "php"
             ],
             "time": "2019-11-08T13:50:10+00:00"
+        },
+        {
+            "name": "nodespark/des-connector",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nodespark/des-connector.git",
+                "reference": "7dc402d3d47dfe6291ca4fab4de5c0a7da185428"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nodespark/des-connector/zipball/7dc402d3d47dfe6291ca4fab4de5c0a7da185428",
+                "reference": "7dc402d3d47dfe6291ca4fab4de5c0a7da185428",
+                "shasum": ""
+            },
+            "require": {
+                "elasticsearch/elasticsearch": "~5.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "nodespark\\DESConnector\\": "src/DESConnector/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-2.1"
+            ],
+            "authors": [
+                {
+                    "name": "Nikolay Ignatov",
+                    "email": "nignatov@nodespark.com",
+                    "homepage": "http://www.nodespark.com",
+                    "role": "Creator and Maintainer"
+                },
+                {
+                    "name": "Lachezar Valchev",
+                    "email": "lachezar.valchev@gmail.com",
+                    "homepage": "https://drupal.org/u/lachezar.valchev",
+                    "role": "Maintainer"
+                }
+            ],
+            "description": "An abstraction library for Elasticsearch Connector module for Drupal.",
+            "homepage": "https://github.com/nodespark/des-connector",
+            "time": "2017-01-21T16:15:15+00:00"
         },
         {
             "name": "paragonie/random_compat",
@@ -3225,6 +3430,52 @@
             ],
             "description": "A polyfill for getallheaders.",
             "time": "2019-03-08T08:55:37+00:00"
+        },
+        {
+            "name": "react/promise",
+            "version": "v2.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/promise.git",
+                "reference": "31ffa96f8d2ed0341a57848cbb84d88b89dd664d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/promise/zipball/31ffa96f8d2ed0341a57848cbb84d88b89dd664d",
+                "reference": "31ffa96f8d2ed0341a57848cbb84d88b89dd664d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.8"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\Promise\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com"
+                }
+            ],
+            "description": "A lightweight implementation of CommonJS Promises/A for PHP",
+            "keywords": [
+                "promise",
+                "promises"
+            ],
+            "time": "2019-01-07T21:25:54+00:00"
         },
         {
             "name": "stack/builder",
@@ -5325,7 +5576,9 @@
     "packages-dev": [],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": [],
+    "stability-flags": {
+        "nodespark/des-connector": 20
+    },
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": [],

--- a/config/sync/core.entity_view_display.block_content.basic.default.yml
+++ b/config/sync/core.entity_view_display.block_content.basic.default.yml
@@ -21,4 +21,5 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
-hidden: {  }
+hidden:
+  search_api_excerpt: true

--- a/config/sync/core.entity_view_display.comment.comment.default.yml
+++ b/config/sync/core.entity_view_display.comment.comment.default.yml
@@ -24,4 +24,5 @@ content:
   links:
     weight: 100
     region: content
-hidden: {  }
+hidden:
+  search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.article.default.yml
+++ b/config/sync/core.entity_view_display.node.article.default.yml
@@ -60,4 +60,5 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
-hidden: {  }
+hidden:
+  search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.article.rss.yml
+++ b/config/sync/core.entity_view_display.node.article.rss.yml
@@ -26,3 +26,4 @@ hidden:
   comment: true
   field_image: true
   field_tags: true
+  search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.article.teaser.yml
+++ b/config/sync/core.entity_view_display.node.article.teaser.yml
@@ -53,3 +53,4 @@ hidden:
   comment: true
   field_image: true
   field_tags: true
+  search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.page.default.yml
+++ b/config/sync/core.entity_view_display.node.page.default.yml
@@ -25,4 +25,5 @@ content:
   links:
     weight: 101
     region: content
-hidden: {  }
+hidden:
+  search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.page.teaser.yml
+++ b/config/sync/core.entity_view_display.node.page.teaser.yml
@@ -27,4 +27,5 @@ content:
   links:
     weight: 101
     region: content
-hidden: {  }
+hidden:
+  search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.school.default.yml
+++ b/config/sync/core.entity_view_display.node.school.default.yml
@@ -25,4 +25,5 @@ content:
     settings: {  }
     third_party_settings: {  }
     region: content
-hidden: {  }
+hidden:
+  search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.school.teaser.yml
+++ b/config/sync/core.entity_view_display.node.school.teaser.yml
@@ -27,4 +27,5 @@ content:
     settings: {  }
     third_party_settings: {  }
     region: content
-hidden: {  }
+hidden:
+  search_api_excerpt: true

--- a/config/sync/core.entity_view_display.user.user.compact.yml
+++ b/config/sync/core.entity_view_display.user.user.compact.yml
@@ -27,3 +27,4 @@ content:
     label: hidden
 hidden:
   member_for: true
+  search_api_excerpt: true

--- a/config/sync/core.entity_view_display.user.user.default.yml
+++ b/config/sync/core.entity_view_display.user.user.default.yml
@@ -27,4 +27,5 @@ content:
       image_link: content
     third_party_settings: {  }
     label: hidden
-hidden: {  }
+hidden:
+  search_api_excerpt: true

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -14,6 +14,7 @@ module:
   dblog: 0
   dynamic_page_cache: 0
   editor: 0
+  elasticsearch_connector: 0
   field: 0
   field_ui: 0
   file: 0
@@ -31,6 +32,7 @@ module:
   quickedit: 0
   rdf: 0
   search: 0
+  search_api: 0
   shortcut: 0
   system: 0
   taxonomy: 0

--- a/config/sync/elasticsearch_connector.cluster.main.yml
+++ b/config/sync/elasticsearch_connector.cluster.main.yml
@@ -1,0 +1,14 @@
+uuid: 7b42af78-63e1-4318-a499-a7ab624d3e21
+langcode: en
+status: '1'
+dependencies: {  }
+cluster_id: main
+name: main
+url: 'https://drupal-static-elasticsearch.ddev.site:9201'
+options:
+  multiple_nodes_connection: false
+  use_authentication: 0
+  authentication_type: Basic
+  username: ''
+  password: ''
+  timeout: '3'

--- a/config/sync/search_api.index.default.yml
+++ b/config/sync/search_api.index.default.yml
@@ -3,15 +3,41 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.storage.node.body
+    - field.storage.node.field_image
     - search_api.server.main
   module:
-    - search_api
     - node
+    - search_api
 id: default
 name: Default
 description: ''
 read_only: false
-field_settings: {  }
+field_settings:
+  body:
+    label: Body
+    datasource_id: 'entity:node'
+    property_path: body
+    type: text
+    dependencies:
+      config:
+        - field.storage.node.body
+  field_image:
+    label: Image
+    datasource_id: 'entity:node'
+    property_path: field_image
+    type: integer
+    dependencies:
+      config:
+        - field.storage.node.field_image
+  title:
+    label: Title
+    datasource_id: 'entity:node'
+    property_path: title
+    type: string
+    dependencies:
+      module:
+        - node
 datasource_settings:
   'entity:node':
     bundles:

--- a/config/sync/search_api.index.default.yml
+++ b/config/sync/search_api.index.default.yml
@@ -1,0 +1,35 @@
+uuid: 4e749ffa-9a41-45bd-8ee5-fe47bce2d48c
+langcode: en
+status: true
+dependencies:
+  config:
+    - search_api.server.main
+  module:
+    - search_api
+    - node
+id: default
+name: Default
+description: ''
+read_only: false
+field_settings: {  }
+datasource_settings:
+  'entity:node':
+    bundles:
+      default: false
+      selected:
+        - article
+    languages:
+      default: true
+      selected: {  }
+processor_settings:
+  add_url: {  }
+  aggregated_field: {  }
+  language_with_fallback: {  }
+  rendered_item: {  }
+tracker_settings:
+  default:
+    indexing_order: fifo
+options:
+  index_directly: true
+  cron_limit: 50
+server: main

--- a/config/sync/search_api.server.main.yml
+++ b/config/sync/search_api.server.main.yml
@@ -1,0 +1,24 @@
+uuid: 3caa798c-7594-4fac-8edd-8a97837c1425
+langcode: en
+status: true
+dependencies:
+  module:
+    - elasticsearch_connector
+id: main
+name: Main
+description: ''
+backend: elasticsearch
+backend_config:
+  cluster_settings:
+    cluster: main
+  fuzziness: auto
+  scheme: http
+  host: localhost
+  port: '9200'
+  path: ''
+  excerpt: false
+  retrieve_data: false
+  highlight_data: false
+  http_method: AUTO
+  autocorrect_spell: true
+  autocorrect_suggest_words: true

--- a/config/sync/search_api.settings.yml
+++ b/config/sync/search_api.settings.yml
@@ -1,0 +1,6 @@
+default_cron_limit: 50
+cron_worker_runtime: 15
+default_tracker: default
+tracking_page_size: 100
+_core:
+  default_config_hash: n7m4vlCPoB3_1C7l13LKYsifmLur4QR71mOD7S_5hSE

--- a/config/sync/system.site.yml
+++ b/config/sync/system.site.yml
@@ -1,5 +1,5 @@
 uuid: cf19c207-fe02-41f0-8711-348cfb15974b
-name: 'Drupal 8 Tests'
+name: 'Static Site & Elasticsearch'
 mail: admin@example.com
 slogan: ''
 page:

--- a/config/sync/tour.tour.search-api-index-fields.yml
+++ b/config/sync/tour.tour.search-api-index-fields.yml
@@ -1,0 +1,101 @@
+uuid: e18bace6-8b85-4867-a767-01279e73aa67
+langcode: en
+status: true
+dependencies:
+  module:
+    - search_api
+_core:
+  default_config_hash: mP2RtTYiDo6dp1q8hXxx2Wgr_1ZvtN7AijjXrwFQV_k
+id: search-api-index-fields
+label: 'Fields indexed in this index'
+module: search_api
+routes:
+  -
+    route_name: entity.search_api_index.fields
+tips:
+  search-api-index-fields-introduction:
+    id: search-api-index-fields-introduction
+    plugin: text
+    label: 'Fields indexed in this index'
+    body: 'This page lists which fields are indexed in this index, grouped by datasource. (Datasource-independent fields are listed under "General".) Indexed fields can be used to add filters or sorting to views or other search displays based on the index. Fields with type "Fulltext" can also be used for fulltext searching.'
+    weight: 1
+  search-api-index-fields-add:
+    id: search-api-index-fields-add
+    plugin: text
+    label: 'Add fields'
+    body: 'With the "Add fields" button you can add additional fields to this index.'
+    weight: 2
+    attributes:
+      data-class: 'button-action[data-drupal-selector="edit-add-field"]'
+  search-api-index-fields-label:
+    id: search-api-index-fields-label
+    plugin: text
+    label: Label
+    body: 'A label for the field that will be used to refer to the field in most places in the user interface.'
+    weight: 3
+    attributes:
+      data-class: 'details-wrapper:nth(0) table thead th:nth(0)'
+  search-api-index-fields-machine-name:
+    id: search-api-index-fields-machine-name
+    plugin: text
+    label: 'Machine name'
+    body: 'The internal ID to use for this field. Can safely be ignored by inexperienced users in most cases. Changing a field''s machine name requires reindexing of the index.'
+    weight: 4
+    attributes:
+      data-class: 'details-wrapper:nth(0) table thead th:nth(1)'
+  search-api-index-fields-property-path:
+    id: search-api-index-fields-property-path
+    plugin: text
+    label: 'Property path'
+    body: 'The internal relationship linking the indexed item to the field, with links being separated by colons (:). This can be useful information for advanced users, but can otherwise be ignored.'
+    weight: 5
+    attributes:
+      data-class: 'details-wrapper:nth(0) table thead th:nth(2)'
+  search-api-index-fields-type:
+    id: search-api-index-fields-type
+    plugin: text
+    label: Type
+    body: 'The data type to use when indexing the field. Determines how a field can be used in searches. For information on the available types, see the <a href="#search-api-data-types-table">"Data types" box</a> at the bottom of the page.'
+    weight: 6
+    attributes:
+      data-class: 'details-wrapper:nth(0) table thead th:nth(3)'
+  search-api-index-fields-boost:
+    id: search-api-index-fields-boost
+    plugin: text
+    label: Boost
+    body: 'Only applicable for fulltext fields. Determines how "important" the field is compared to other fulltext fields, to influence scoring of fulltext searches.'
+    weight: 7
+    attributes:
+      data-class: 'details-wrapper:nth(0) table thead th:nth(4)'
+  search-api-index-fields-edit:
+    id: search-api-index-fields-edit
+    plugin: text
+    label: 'Edit field'
+    body: 'Some fields have additional configuration available, in which case an "Edit" link is displayed in the "Operations" column.'
+    weight: 8
+    attributes:
+      data-class: 'details-wrapper:nth(0) table tbody td:nth(5) a'
+  search-api-index-fields-remove:
+    id: search-api-index-fields-remove
+    plugin: text
+    label: 'Remove field'
+    body: 'Removes a field from the index again. (Note: Sometimes, a field is required (for example, by a processor) and cannot be removed.)'
+    weight: 9
+    attributes:
+      data-class: 'details-wrapper:nth(0) table tbody td:nth(6) a'
+  search-api-index-fields-submit:
+    id: search-api-index-fields-submit
+    plugin: text
+    label: 'Save changes'
+    body: 'This saves all changes made to the fields for this index. Until this button is pressed, all added, changed or removed fields will only be stored temporarily and not effect the actual index used in the rest of the site.'
+    weight: 10
+    attributes:
+      data-id: edit-actions-submit
+  search-api-index-fields-cancel:
+    id: search-api-index-fields-cancel
+    plugin: text
+    label: 'Cancel changes'
+    body: 'If you have made changes to the index''s fields but not yet saved them, the "Cancel" link lets you discard those changes.'
+    weight: 10
+    attributes:
+      data-id: edit-actions-cancel

--- a/config/sync/tour.tour.search-api-index-form.yml
+++ b/config/sync/tour.tour.search-api-index-form.yml
@@ -1,0 +1,71 @@
+uuid: e815b644-f5b5-4156-8a0e-a6033db68f7e
+langcode: en
+status: true
+dependencies:
+  module:
+    - search_api
+_core:
+  default_config_hash: TK3PjpP4I6WFh5JDY_L_c5XCiTyAZBBA9z0M9pcGjzo
+id: search-api-index-form
+label: 'Add or edit a Search API index'
+module: search_api
+routes:
+  -
+    route_name: entity.search_api_index.add_form
+  -
+    route_name: entity.search_api_index.edit_form
+tips:
+  search-api-index-form-introduction:
+    id: search-api-index-form-introduction
+    plugin: text
+    label: 'Adding or editing an index'
+    body: 'This form can be used to edit an existing index or add a new index to your site. Indexes define a set of data that will be indexed and can then be searched.'
+    weight: 1
+  search-api-index-form-name:
+    id: search-api-index-form-name
+    plugin: text
+    label: 'Index name'
+    body: 'Enter a name to identify this index. For example, "Content index". This will only be displayed in the admin user interface.'
+    weight: 2
+    attributes:
+      data-id: edit-name
+  search-api-index-form-datasources:
+    id: search-api-index-form-datasources
+    plugin: text
+    label: Datasources
+    body: 'Datasources define the types of items that will be indexed in this index. By default, all content entities (like content, comments and taxonomy terms) will be available here, but modules can also add their own.'
+    weight: 3
+    attributes:
+      data-id: edit-datasources
+  search-api-index-form-tracker:
+    id: search-api-index-form-tracker
+    plugin: text
+    label: Tracker
+    body: 'An index''s tracker is the system that keeps track of which items there are available for the index, and which of them still need to be indexed. Changing the tracker of an existing index will lead to reindexing of all items.'
+    weight: 4
+    attributes:
+      data-id: edit-tracker
+  search-api-index-form-server:
+    id: search-api-index-form-server
+    plugin: text
+    label: Server
+    body: 'The search server that the index should use for indexing and searching. If no server is selected here, the index cannot be enabled. An index can only have one server, but a server can have any number of indexes.'
+    weight: 5
+    attributes:
+      data-id: edit-server
+  search-api-index-form-description:
+    id: search-api-index-form-description
+    plugin: text
+    label: 'Index description'
+    body: 'Optionally, enter a description to explain the function of the index in more detail. This will only be displayed in the admin user interface.'
+    weight: 6
+    attributes:
+      data-id: edit-description
+  search-api-index-form-options:
+    id: search-api-index-form-options
+    plugin: text
+    label: 'Advanced options'
+    body: 'These options allow more detailed configuration of index behavior, but can usually safely be ignored by inexperienced users.'
+    weight: 7
+    attributes:
+      data-id: edit-options

--- a/config/sync/tour.tour.search-api-index-processors.yml
+++ b/config/sync/tour.tour.search-api-index-processors.yml
@@ -1,0 +1,45 @@
+uuid: b35383ec-4a08-49ae-b8a2-cbc8eb33f478
+langcode: en
+status: true
+dependencies:
+  module:
+    - search_api
+_core:
+  default_config_hash: LqXAZO_yZPho3Pueh85e-NzQ3DmI5rNBf6_q8McKUqc
+id: search-api-index-processors
+label: 'Processors used for this index'
+module: search_api
+routes:
+  -
+    route_name: entity.search_api_index.processors
+tips:
+  search-api-index-processors-introduction:
+    id: search-api-index-processors-introduction
+    plugin: text
+    label: 'Processors used for this index'
+    body: 'Processors customize different aspects of an index''s functionality. They can keep items from being indexed, change how certain fields are indexed and influence searches.'
+    weight: 1
+  search-api-index-processors-enable:
+    id: search-api-index-processors-enable
+    plugin: text
+    label: 'Enable processors'
+    body: 'This lists all processors available for this index and lets you choose the ones that should be active. (Note: Some processors cannot be disabled.)'
+    weight: 2
+    attributes:
+      data-id: edit-status
+  search-api-index-processors-weights:
+    id: search-api-index-processors-weights
+    plugin: text
+    label: 'Processor order'
+    body: 'This shows you which enabled processors will be active in the different parts of the indexing/searching workflow, and lets you re-arrange them. This should usually not be necessary, and only be used by advanced users as some processors will lead to unexpected results when used in the wrong order.'
+    weight: 3
+    attributes:
+      data-id: edit-weights
+  search-api-index-processors-settings:
+    id: search-api-index-processors-settings
+    plugin: text
+    label: 'Processor settings'
+    body: 'Some processors have additional configuration available, which you are able to change here.'
+    weight: 4
+    attributes:
+      data-class: form-type-vertical-tabs

--- a/config/sync/tour.tour.search-api-index.yml
+++ b/config/sync/tour.tour.search-api-index.yml
@@ -1,0 +1,109 @@
+uuid: 18aaaaaa-f083-4557-98a5-6554d776ab47
+langcode: en
+status: true
+dependencies:
+  module:
+    - search_api
+_core:
+  default_config_hash: vrJLX_BEpVcWa6OU7FvRAUfErBOxQBhPtzuKeNo4M2M
+id: search-api-index
+label: 'Information about an index'
+module: search_api
+routes:
+  -
+    route_name: entity.search_api_index.canonical
+tips:
+  search-api-index-introduction:
+    id: search-api-index-introduction
+    plugin: text
+    label: 'Information about an index'
+    body: 'This page shows a summary of a search index and its status.'
+    weight: 1
+  search-api-index-index-status:
+    id: search-api-index-index-status
+    plugin: text
+    label: 'Index status'
+    body: 'This gives a summary about how many items are known for this index, and how many have been indexed in their latest version. Items that are not indexed yet cannot be found by searches.'
+    weight: 2
+    attributes:
+      data-class: search-api-index-status
+  search-api-index-status:
+    id: search-api-index-status
+    plugin: text
+    label: Status
+    body: 'Shows whether the index is currently enabled or disabled.'
+    weight: 3
+    attributes:
+      data-class: search-api-index-summary--status
+  search-api-index-datasources:
+    id: search-api-index-datasources
+    plugin: text
+    label: Datasources
+    body: 'Lists all datasources that are enabled for this index.'
+    weight: 4
+    attributes:
+      data-class: search-api-index-summary--datasource
+  search-api-index-tracker:
+    id: search-api-index-tracker
+    plugin: text
+    label: Tracker
+    body: 'The tracker used by the index. Only one ("Default") is available by default.'
+    weight: 5
+    attributes:
+      data-class: search-api-index-summary--tracker
+  search-api-index-server:
+    id: search-api-index-server
+    plugin: text
+    label: Server
+    body: 'If the index is attached to a server, this server is listed here.'
+    weight: 6
+    attributes:
+      data-class: search-api-index-summary--server
+  search-api-index-server-index-status:
+    id: search-api-index-server-index-status
+    plugin: text
+    label: 'Server index status'
+    body: 'For enabled indexes, the number of items that can actually be retrieved from the server is listed here. For reasons why this number might differ from the number under "Index status", <a href="https://www.drupal.org/docs/8/modules/search-api/getting-started/frequently-asked-questions#server-index-status">see the module''s documentation</a>.'
+    weight: 7
+    attributes:
+      data-class: search-api-index-summary--server-index-status
+  search-api-index-cron-batch-size:
+    id: search-api-index-cron-batch-size
+    plugin: text
+    label: 'Cron batch size'
+    body: 'The number of items that will be indexed at once during cron runs.'
+    weight: 8
+    attributes:
+      data-class: search-api-index-summary--cron-batch-size
+  search-api-index-index-now:
+    id: search-api-index-remove
+    plugin: text
+    label: 'Start indexing now'
+    body: 'The "Start indexing now" form allows indexing items manually right away, with a batch process. Otherwise, items are only indexed during cron runs. The form might be disabled if indexing is currently not possible for some reason, or not necessary.'
+    weight: 9
+    attributes:
+      data-id: edit-index
+  search-api-index-tracking:
+    id: search-api-index-tracking
+    plugin: text
+    label: 'Track items for index'
+    body: 'In certain situations, the index''s tracker doesn''t have the latest state of the items available for indexing. This will be automatically rectified during cron runs, but can also be manually triggered here, with the "Track now" button.'
+    weight: 10
+    attributes:
+      data-id: edit-tracking
+  search-api-index-reindex:
+    id: search-api-index-reindex
+    plugin: text
+    label: 'Queue all items for reindexing'
+    body: 'This will queue all items on this index for reindexing. Previously indexed data will remain on the search server, so searches on this index will continue to yield results.'
+    weight: 11
+    attributes:
+      data-id: edit-reindex
+  search-api-index-clear:
+    id: search-api-index-clear
+    plugin: text
+    label: 'Clear all indexed data'
+    body: 'This will remove all indexed content for this index from the search server and queue it for reindexing. Searches on this index will not return any results until items are reindexed.'
+    weight: 12
+    attributes:
+      data-id: edit-clear

--- a/config/sync/tour.tour.search-api-server-form.yml
+++ b/config/sync/tour.tour.search-api-server-form.yml
@@ -1,0 +1,47 @@
+uuid: e8719c0b-3d4e-4291-99d7-3f461c92a60c
+langcode: en
+status: true
+dependencies:
+  module:
+    - search_api
+_core:
+  default_config_hash: wiTKND8Vi_2guGPCSCjciyClZs7LVIQ_ruTzlkE_Bg0
+id: search-api-server-form
+label: 'Add or edit a Search API server'
+module: search_api
+routes:
+  -
+    route_name: entity.search_api_server.add_form
+  -
+    route_name: entity.search_api_server.edit_form
+tips:
+  search-api-server-form-introduction:
+    id: search-api-server-form-introduction
+    plugin: text
+    label: 'Adding or editing a Server'
+    body: 'This form can be used to edit an existing server or add a new server to your site. Servers will hold your indexed data.'
+    weight: 1
+  search-api-server-form-name:
+    id: search-api-server-form-name
+    plugin: text
+    label: 'Server name'
+    body: 'Enter a name to identify this server. For example, "Solr server". This will only be displayed in the admin user interface.'
+    weight: 2
+    attributes:
+      data-id: edit-name
+  search-api-server-form-description:
+    id: search-api-server-form-description
+    plugin: text
+    label: 'Server description'
+    body: 'Optionally, enter a description to explain the function of the server in more detail. This will only be displayed in the admin user interface.'
+    weight: 3
+    attributes:
+      data-id: edit-description
+  search-api-server-form-backend:
+    id: search-api-server-form-backend
+    plugin: text
+    label: 'Server backend'
+    body: 'Servers can be based on different technologies. These are called "backends". A server uses exactly one backend and cannot change it later. You can make the "Database" backend available by enabling the "Database Search" module. Another very common backend is <a href="https://www.drupal.org/project/search_api_solr">"Solr"</a>, which requires to be set up separately.'
+    weight: 4
+    attributes:
+      data-id: edit-backend

--- a/config/sync/tour.tour.search-api-server.yml
+++ b/config/sync/tour.tour.search-api-server.yml
@@ -1,0 +1,53 @@
+uuid: 633c2d4f-afbb-4324-8e51-e52bf51315c9
+langcode: en
+status: true
+dependencies:
+  module:
+    - search_api
+_core:
+  default_config_hash: j-YgGnx-C5I3OTFsDsNkTyPC8zH7ZQyBMvmZ6gUMH3Q
+id: search-api-server
+label: 'Information about a server'
+module: search_api
+routes:
+  -
+    route_name: entity.search_api_server.canonical
+tips:
+  search-api-server-introduction:
+    id: search-api-server-introduction
+    plugin: text
+    label: 'Information about a server'
+    body: 'This page shows a summary of a search server.'
+    weight: 1
+  search-api-server-status:
+    id: search-api-server-status
+    plugin: text
+    label: Status
+    body: 'Shows whether the server is currently enabled or disabled.'
+    weight: 2
+    attributes:
+      data-class: search-api-server-summary--status
+  search-api-server-backend:
+    id: search-api-server-backend
+    plugin: text
+    label: 'Backend class'
+    body: 'The backend plugin used for this server. The backend plugin determines how items are indexed and searched – for example, using the database or an Apache Solr server.'
+    weight: 3
+    attributes:
+      data-class: search-api-server-summary--backend
+  search-api-server-indexes:
+    id: search-api-server-indexes
+    plugin: text
+    label: 'Search indexes'
+    body: 'Lists all search indexes that are attached to this server.'
+    weight: 4
+    attributes:
+      data-class: search-api-server-summary--indexes
+  search-api-server-clear:
+    id: search-api-server-clear
+    plugin: text
+    label: 'Delete all indexed data'
+    body: 'This will permanently remove all data currently indexed on this server for indexes that aren''t read-only. Items are queued for reindexing. Until reindexing occurs, searches for the affected indexes will not return any results.'
+    weight: 5
+    attributes:
+      data-id: edit-clear


### PR DESCRIPTION
I tried to extend Umami, but that would require a core patch, and make things more complicated. I wish to provide here a "copy and use" example. So we'll having our own `server` profile that extends `Standard` and adds our own config.

PR adds ES config

![image](https://user-images.githubusercontent.com/125707/78608363-74851780-7869-11ea-9726-ad881c62e73f.png)
